### PR TITLE
Update the URL of CDNJS's p5 repository

### DIFF
--- a/chp00_introduction/NOC_I_01_RandomWalkTraditional/index.html
+++ b/chp00_introduction/NOC_I_01_RandomWalkTraditional/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp00_introduction/NOC_I_02_RandomDistribution/index.html
+++ b/chp00_introduction/NOC_I_02_RandomDistribution/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp00_introduction/NOC_I_03_RandomWalkTendsToRight/index.html
+++ b/chp00_introduction/NOC_I_03_RandomWalkTendsToRight/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp00_introduction/NOC_I_04_Gaussian/index.html
+++ b/chp00_introduction/NOC_I_04_Gaussian/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp00_introduction/NOC_I_05_NoiseWalk/index.html
+++ b/chp00_introduction/NOC_I_05_NoiseWalk/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="noise.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp00_introduction/Noise1D/index.html
+++ b/chp00_introduction/Noise1D/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="noise.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp01_vectors/NOC_1_01_bouncingball_novectors/index.html
+++ b/chp01_vectors/NOC_1_01_bouncingball_novectors/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp01_vectors/NOC_1_02_bouncingball_vectors/index.html
+++ b/chp01_vectors/NOC_1_02_bouncingball_vectors/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp01_vectors/NOC_1_02_bouncingball_vectors_object/index.html
+++ b/chp01_vectors/NOC_1_02_bouncingball_vectors_object/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="ball.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp01_vectors/NOC_1_03_vector_subtraction/index.html
+++ b/chp01_vectors/NOC_1_03_vector_subtraction/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp01_vectors/NOC_1_04_vector_multiplication/index.html
+++ b/chp01_vectors/NOC_1_04_vector_multiplication/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp01_vectors/NOC_1_05_vector_magnitude/index.html
+++ b/chp01_vectors/NOC_1_05_vector_magnitude/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp01_vectors/NOC_1_06_vector_normalize/index.html
+++ b/chp01_vectors/NOC_1_06_vector_normalize/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp01_vectors/NOC_1_07_motion101/index.html
+++ b/chp01_vectors/NOC_1_07_motion101/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp01_vectors/NOC_1_08_motion101_acceleration/index.html
+++ b/chp01_vectors/NOC_1_08_motion101_acceleration/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp01_vectors/NOC_1_09_motion101_acceleration/index.html
+++ b/chp01_vectors/NOC_1_09_motion101_acceleration/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp01_vectors/NOC_1_10_motion101_acceleration/index.html
+++ b/chp01_vectors/NOC_1_10_motion101_acceleration/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp01_vectors/NOC_1_11_motion101_acceleration_array/index.html
+++ b/chp01_vectors/NOC_1_11_motion101_acceleration_array/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp02_forces/NOC_2_01_forces/index.html
+++ b/chp02_forces/NOC_2_01_forces/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp02_forces/NOC_2_02_forces_many/index.html
+++ b/chp02_forces/NOC_2_02_forces_many/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp02_forces/NOC_2_03_forces_many_realgravity/index.html
+++ b/chp02_forces/NOC_2_03_forces_many_realgravity/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp02_forces/NOC_2_04_forces_friction/index.html
+++ b/chp02_forces/NOC_2_04_forces_friction/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp02_forces/NOC_2_05_fluidresistance/index.html
+++ b/chp02_forces/NOC_2_05_fluidresistance/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="liquid.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp02_forces/NOC_2_06_attraction/index.html
+++ b/chp02_forces/NOC_2_06_attraction/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="attractor.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp02_forces/NOC_2_07_attraction_many/index.html
+++ b/chp02_forces/NOC_2_07_attraction_many/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="attractor.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp02_forces/NOC_2_08_mutualattraction/index.html
+++ b/chp02_forces/NOC_2_08_mutualattraction/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp03_oscillation/NOC_3_01_angular_motion/index.html
+++ b/chp03_oscillation/NOC_3_01_angular_motion/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_01_angular_motion </title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_02_forces_angular_motion/index.html
+++ b/chp03_oscillation/NOC_3_02_forces_angular_motion/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_02_forces_angular_motion</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="attractor.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp03_oscillation/NOC_3_03_pointing_velocity/index.html
+++ b/chp03_oscillation/NOC_3_03_pointing_velocity/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_03_pointing_velocity</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 

--- a/chp03_oscillation/NOC_3_04_PolarToCartesian/index.html
+++ b/chp03_oscillation/NOC_3_04_PolarToCartesian/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_04_PolarToCartesian</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_05_simple_harmonic_motion/index.html
+++ b/chp03_oscillation/NOC_3_05_simple_harmonic_motion/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_05_simple_harmonic_motion</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_06_simple_harmonic_motion/index.html
+++ b/chp03_oscillation/NOC_3_06_simple_harmonic_motion/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_06_simple_harmonic_motion</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_07_oscillating_objects/index.html
+++ b/chp03_oscillation/NOC_3_07_oscillating_objects/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_07_oscillating_objects</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="oscillator.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp03_oscillation/NOC_3_08_static_wave_lines/index.html
+++ b/chp03_oscillation/NOC_3_08_static_wave_lines/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_08_static_wave_lines</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_09_exercise_additive_wave/index.html
+++ b/chp03_oscillation/NOC_3_09_exercise_additive_wave/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_09_exercise_additive_wave</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_09_wave/index.html
+++ b/chp03_oscillation/NOC_3_09_wave/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_09_wave</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 <body>

--- a/chp03_oscillation/NOC_3_10_PendulumExample/index.html
+++ b/chp03_oscillation/NOC_3_10_PendulumExample/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_07_oscillating_objects</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="pendulum.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp03_oscillation/NOC_3_10_PendulumExampleSimplified/index.html
+++ b/chp03_oscillation/NOC_3_10_PendulumExampleSimplified/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_07_oscillating_objects</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="pendulum.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp03_oscillation/NOC_3_11_spring/index.html
+++ b/chp03_oscillation/NOC_3_11_spring/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_11_spring</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="spring.js"></script>
   <script language="javascript" type="text/javascript" src="bob.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp03_oscillation/NOC_Exercise_3_02/index.html
+++ b/chp03_oscillation/NOC_Exercise_3_02/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_03_pointing_velocity</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="mover.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 

--- a/chp04_systems/NOC_4_01_SingleParticle/index.html
+++ b/chp04_systems/NOC_4_01_SingleParticle/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_4_01_SingleParticle</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp04_systems/NOC_4_02_ArrayParticles/index.html
+++ b/chp04_systems/NOC_4_02_ArrayParticles/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_4_02_ArrayParticles</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp04_systems/NOC_4_03_ParticleSystemClass/index.html
+++ b/chp04_systems/NOC_4_03_ParticleSystemClass/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_4_03_ParticleSystemClass</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="particle_system.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp04_systems/NOC_4_04_SystemofSystems/index.html
+++ b/chp04_systems/NOC_4_04_SystemofSystems/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>NOC_4_04_SystemofSystems</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="particle_system.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp04_systems/NOC_4_05_ParticleSystemInheritancePolymorphism/index.html
+++ b/chp04_systems/NOC_4_05_ParticleSystemInheritancePolymorphism/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_4_05_ParticleSystemInheritancePolymorphism</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="confetti.js"></script>
   <script language="javascript" type="text/javascript" src="particle_system.js"></script>

--- a/chp04_systems/NOC_4_06_ParticleSystemForces/index.html
+++ b/chp04_systems/NOC_4_06_ParticleSystemForces/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_01_angular_motion </title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="particle_system.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp04_systems/NOC_4_07_ParticleSystemForcesRepeller/index.html
+++ b/chp04_systems/NOC_4_07_ParticleSystemForcesRepeller/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_3_01_angular_motion </title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="particle_system.js"></script>
   <script language="javascript" type="text/javascript" src="repeller.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_01_exercise/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_01_exercise/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>NOC_5_01_Exercise</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="box.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp05_libraries/box2d-html5/NOC_5_01_exercise_solved/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_01_exercise_solved/index.html
@@ -3,7 +3,7 @@
   <title>NOC_5_01_Exercise_Solved</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <script language="javascript" type="text/javascript" src="box.js"></script>
 </head>

--- a/chp05_libraries/box2d-html5/NOC_5_02_Boxes/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_02_Boxes/index.html
@@ -3,7 +3,7 @@
   <title>NOC_5_02_Boxes</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="boundary.js"></script>
   <script language="javascript" type="text/javascript" src="box.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_03_ChainShape_Simple/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_03_ChainShape_Simple/index.html
@@ -3,7 +3,7 @@
   <title>NOC_5_02_Boxes</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="surface.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_04_Polygons/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_04_Polygons/index.html
@@ -3,7 +3,7 @@
   <title>NOC_5_02_Boxes</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="customshape.js"></script>
   <script language="javascript" type="text/javascript" src="boundary.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_05_MultiShapes/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_05_MultiShapes/index.html
@@ -3,7 +3,7 @@
   <title>The Nature of Code 5.5 Box2D Multiple Shapes, One Body</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="boundary.js"></script>
   <script language="javascript" type="text/javascript" src="lollipop.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_06_DistanceJoint/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_06_DistanceJoint/index.html
@@ -3,7 +3,7 @@
   <title>The Nature of Code 5.6 DistanceJoint</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="boundary.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="pair.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_07_RevoluteJoint/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_07_RevoluteJoint/index.html
@@ -3,8 +3,8 @@
   <title>The Nature of Code 5.7 RevoluteJoint</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>  
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>  
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="box.js"></script>
   <script language="javascript" type="text/javascript" src="windmill.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_08_MouseJoint/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_08_MouseJoint/index.html
@@ -3,7 +3,7 @@
   <title>The Nature of Code 5.6 DistanceJoint</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="boundary.js"></script>
   <script language="javascript" type="text/javascript" src="box.js"></script>
   <script language="javascript" type="text/javascript" src="spring.js"></script>

--- a/chp05_libraries/box2d-html5/NOC_5_09_CollisionListening/index.html
+++ b/chp05_libraries/box2d-html5/NOC_5_09_CollisionListening/index.html
@@ -3,7 +3,7 @@
   <title>The Nature of Code 5.9 Collision Listening</title>
   <script language="javascript" type="text/javascript" src="../lib/box2d-html5.js"></script>
   <script language="javascript" type="text/javascript" src="../lib/box2d-helper.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
   <script language="javascript" type="text/javascript" src="boundary.js"></script>
   <script language="javascript" type="text/javascript" src="customlistener.js"></script>

--- a/chp06_agents/NOC_6_01_Seek/index.html
+++ b/chp06_agents/NOC_6_01_Seek/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp06_agents/NOC_6_02_Arrive/index.html
+++ b/chp06_agents/NOC_6_02_Arrive/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.2 Arrive</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp06_agents/NOC_6_03_StayWithinWalls/index.html
+++ b/chp06_agents/NOC_6_03_StayWithinWalls/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.3 Stay Within Walls</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp06_agents/NOC_6_04_FlowField/index.html
+++ b/chp06_agents/NOC_6_04_FlowField/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="flowfield.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp06_agents/NOC_6_05_PathFollowing_Simple/index.html
+++ b/chp06_agents/NOC_6_05_PathFollowing_Simple/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="path.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp06_agents/NOC_6_06_PathFollowing/index.html
+++ b/chp06_agents/NOC_6_06_PathFollowing/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="path.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp06_agents/NOC_6_07_Separation/index.html
+++ b/chp06_agents/NOC_6_07_Separation/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp06_agents/NOC_6_08_SeparationAndSeek/index.html
+++ b/chp06_agents/NOC_6_08_SeparationAndSeek/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="vehicle.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp06_agents/NOC_6_09_Flocking/index.html
+++ b/chp06_agents/NOC_6_09_Flocking/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>The Nature of Code Example 6.1 Seek</title>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="boid.js"></script>
   <script language="javascript" type="text/javascript" src="flock.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp07_CA/Exercise_7_01_WolframCA_randomizedrules/index.html
+++ b/chp07_CA/Exercise_7_01_WolframCA_randomizedrules/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 	<meta charset="UTF-8">
-		<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+		<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   		<script language="javascript" type="text/javascript" src="sketch.js"></script>
 		<script language="javascript" type="text/javascript" src="CA.js"></script>
 	</head>

--- a/chp07_CA/Exercise_7_04_WolframCA_scrolling/index.html
+++ b/chp07_CA/Exercise_7_04_WolframCA_scrolling/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 	<script language="javascript" type="text/javascript" src="CA.js"></script>
 </head>

--- a/chp07_CA/GameOfLifeWrapAround/index.html
+++ b/chp07_CA/GameOfLifeWrapAround/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
-		<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+		<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   		<script language="javascript" type="text/javascript" src="sketch.js"></script>
 		<script language="javascript" type="text/javascript" src="GOL.js"></script>
 	</head>

--- a/chp07_CA/NOC_7_01_WolframCA_simple/index.html
+++ b/chp07_CA/NOC_7_01_WolframCA_simple/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 	<script language="javascript" type="text/javascript" src="CA.js"></script>
 </head>

--- a/chp07_CA/NOC_7_02_GameOfLifeSimple/index.html
+++ b/chp07_CA/NOC_7_02_GameOfLifeSimple/index.html
@@ -1,8 +1,8 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.3.16/p5.js"></script>  
-  <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.3.16/addons/p5.dom.js"></script> 
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.3.16/p5.js"></script>  
+  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.3.16/addons/p5.dom.js"></script> 
   		<script language="javascript" type="text/javascript" src="sketch.js"></script>
 		<script language="javascript" type="text/javascript" src="GOL.js"></script>
 	</head>

--- a/chp07_CA/NOC_7_03_GameOfLifeOOP/index.html
+++ b/chp07_CA/NOC_7_03_GameOfLifeOOP/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 	<script language="javascript" type="text/javascript" src="Cell.js"></script>
 </head>

--- a/chp08_fractals/NOC_8_01_Recursion/index.html
+++ b/chp08_fractals/NOC_8_01_Recursion/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp08_fractals/NOC_8_02_Recursion/index.html
+++ b/chp08_fractals/NOC_8_02_Recursion/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp08_fractals/NOC_8_03_Recursion/index.html
+++ b/chp08_fractals/NOC_8_03_Recursion/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp08_fractals/NOC_8_04_CantorSet/index.html
+++ b/chp08_fractals/NOC_8_04_CantorSet/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/chp08_fractals/NOC_8_05_Koch/index.html
+++ b/chp08_fractals/NOC_8_05_Koch/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-  		<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  		<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
 		<script language="javascript" type="text/javascript" src="KochLine.js"></script>
 		<script language="javascript" type="text/javascript" src="KochFractal.js"></script>
 		<script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/chp08_fractals/NOC_8_05_KochSimple/index.html
+++ b/chp08_fractals/NOC_8_05_KochSimple/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+		<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   		<script language="javascript" type="text/javascript" src="sketch.js"></script>
   		<script language="javascript" type="text/javascript" src="KochLine.js"></script>
 	</head>

--- a/chp08_fractals/NOC_8_06_Tree/index.html
+++ b/chp08_fractals/NOC_8_06_Tree/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-  		<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+  		<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
   		<script language="javascript" type="text/javascript" src="sketch.js"></script>
 	</head>
 

--- a/chp08_fractals/NOC_8_07_TreeStochastic/index.html
+++ b/chp08_fractals/NOC_8_07_TreeStochastic/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
-  	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-    <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+  	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 	</head>
 

--- a/chp08_fractals/NOC_8_08_SimpleLSystem/index.html
+++ b/chp08_fractals/NOC_8_08_SimpleLSystem/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
-    <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-    <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/addons/p5.dom.js"></script>
+    <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.js"></script>
  	  <script language="javascript" type="text/javascript" src="sketch.js"></script>
 	</head>
 

--- a/chp08_fractals/NOC_8_09_LSystem/index.html
+++ b/chp08_fractals/NOC_8_09_LSystem/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
     <script language="javascript" type="text/javascript" src="sketch.js"></script>
     <script language="javascript" type="text/javascript" src="LSystem.js"></script>
     <script language="javascript" type="text/javascript" src="Rule.js"></script>

--- a/chp10_nn/NOC_10_01_Perceptron/index.html
+++ b/chp10_nn/NOC_10_01_Perceptron/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.8/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
 	<script language="javascript" type="text/javascript" src="perceptron.js"></script>
 	<script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>

--- a/chp10_nn/NOC_10_03_NetworkViz/index.html
+++ b/chp10_nn/NOC_10_03_NetworkViz/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
 	<script language="javascript" type="text/javascript" src="neuron.js"></script>
   <script language="javascript" type="text/javascript" src="connection.js"></script>
   <script language="javascript" type="text/javascript" src="network.js"></script>

--- a/chp10_nn/NOC_10_04_NetworkAnimation/index.html
+++ b/chp10_nn/NOC_10_04_NetworkAnimation/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js"></script>
 	<script language="javascript" type="text/javascript" src="neuron.js"></script>
   <script language="javascript" type="text/javascript" src="connection.js"></script>
   <script language="javascript" type="text/javascript" src="network.js"></script>


### PR DESCRIPTION
The URLs was missing the 'https:' part, producing an error. For example, in Chrome :

```
index.html:2 GET file://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.js net::ERR_FILE_NOT_FOUND
```

Also, I took the opportunity to update `p5.js` and `p5.dom.js`to the version number currently avalaible on CDNJS.