### PR TITLE
Remove the redundant line of code from NOC_I_03_RandomWalkTendsToRight

### DIFF
--- a/chp00_introduction/NOC_I_03_RandomWalkTendsToRight/sketch.js
+++ b/chp00_introduction/NOC_I_03_RandomWalkTendsToRight/sketch.js
@@ -27,7 +27,6 @@ class Walker{
   };
 
   step(){
-    let choice = floor(random(4));
     let r = random(1);
       // A 40% of moving to the right!
     if (r < 0.4) {


### PR DESCRIPTION
The following line of code
```
let choice = floor(random(4));
```
is redundant. The variable `choice` does not play any role. So it should be removed.