### PR TITLE
Uncomment p5.Vector.random2D()

### DIFF
--- a/chp01_vectors/NOC_1_09_motion101_acceleration/mover.js
+++ b/chp01_vectors/NOC_1_09_motion101_acceleration/mover.js
@@ -14,10 +14,11 @@ class Mover{
 
   update() {
 
-    // this.acceleration = p5.Vector.random2D();
-    // random2D() not implemented? doing raw math for now instead
-    var angle = random(TWO_PI);
-    this.acceleration = createVector(cos(angle),sin(angle));
+    this.acceleration = p5.Vector.random2D();
+    // If random2D() does not work, use the following code
+    // var angle = random(TWO_PI);
+    // this.acceleration = createVector(cos(angle),sin(angle));
+    
     this.acceleration.mult(random(2));
 
     this.velocity.add(this.acceleration);

--- a/chp01_vectors/NOC_1_09_motion101_acceleration/mover.js
+++ b/chp01_vectors/NOC_1_09_motion101_acceleration/mover.js
@@ -13,12 +13,7 @@ class Mover{
   }
 
   update() {
-
     this.acceleration = p5.Vector.random2D();
-    // If random2D() does not work, use the following code
-    // var angle = random(TWO_PI);
-    // this.acceleration = createVector(cos(angle),sin(angle));
-    
     this.acceleration.mult(random(2));
 
     this.velocity.add(this.acceleration);


### PR DESCRIPTION
As the `random2D()` function does work on p5.js Web Editor
(see my sketch at https://editor.p5js.org/masakudamatsu/sketches/o578MJ0S9A)
I uncomment `this.acceleration = p5.Vector.random2D();`.
Instead, the workaround code is commented out (not deleted in case someone needs it).