### PR TITLE
Off by one error

### DIFF
--- a/chp09_ga/NOC_9_01_GA_Shakespeare/DNA.js
+++ b/chp09_ga/NOC_9_01_GA_Shakespeare/DNA.js
@@ -13,7 +13,7 @@
 //      -- mutate DNA
 
 function newChar() {
-  let c = floor(random(63, 122));
+  let c = floor(random(63, 123));
   if (c === 63) c = 32;
   if (c === 64) c = 46;
 

--- a/chp09_ga/NOC_9_01_GA_Shakespeare_simplified/DNA.js
+++ b/chp09_ga/NOC_9_01_GA_Shakespeare_simplified/DNA.js
@@ -13,7 +13,7 @@
 //      -- mutate DNA
 
 function newChar() {
-  let c = floor(random(64, 122));
+  let c = floor(random(64, 123));
   if (c === 64) c = 32;
 
   return String.fromCharCode(c);


### PR DESCRIPTION
I was experimenting with this example and discovered that it would never find a lower case 'z'  I have fixed the code and it should be able to find targets using words with z's in them.  -rene 