### PR TITLE
remove undefined mover.js

### DIFF
--- a/chp01_vectors/NOC_1_05_vector_magnitude/index.html
+++ b/chp01_vectors/NOC_1_05_vector_magnitude/index.html
@@ -8,7 +8,6 @@
 </head>
 
 <body>
-  <script src="mover.js"></script>
   <script src="sketch.js"></script>
 </body>
 


### PR DESCRIPTION
There is no 'mover.js'. The sketch still works but causes a 404 fetching the file, so it's removed.