### PR TITLE
Fix not a function error resolves #116

### DIFF
--- a/chp00_introduction/NOC_I_05_NoiseWalk/sketch.js
+++ b/chp00_introduction/NOC_I_05_NoiseWalk/sketch.js
@@ -11,7 +11,7 @@ function setup() {
 }
 
 function draw() {
-  walker.step();
+  walker.walk();
   walker.display();
 }
 


### PR DESCRIPTION
Fixes #116

A problem outlined in the issue is whether the .step() should be renamed to .walk(), or walk() should be renamed to step(). I had a look at the history of the file, and it looks like it has always been walk(), so I changed .step() to .walk().