### PR TITLE
fix step to walk in NOC_I_05_NoiseWalk and merge conflict

### DIFF
--- a/chp00_introduction/NOC_I_05_NoiseWalk/sketch.js
+++ b/chp00_introduction/NOC_I_05_NoiseWalk/sketch.js
@@ -11,7 +11,7 @@ function setup() {
 }
 
 function draw() {
-  walker.step();
+  walker.walk();
   walker.display();
 }
 

--- a/chp01_vectors/NOC_1_02_bouncingball_vectors/index.html
+++ b/chp01_vectors/NOC_1_02_bouncingball_vectors/index.html
@@ -2,26 +2,13 @@
 <html>
 
 <head>
-<<<<<<< HEAD
-<<<<<<< HEAD
-  <script language="javascript" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"></script>
-  <script language="javascript" type="text/javascript" src="sketch.js"></script>
-=======
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-=======
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/p5.min.js"></script>
->>>>>>> master
   <meta charset="utf-8" />
->>>>>>> master
 </head>
 
 <body>
   <script src="sketch.js"></script>
 </body>
-<<<<<<< HEAD
-</html>
-=======
 
 </html>
->>>>>>> master


### PR DESCRIPTION
I solved this error in the [sketch.js](https://github.com/nature-of-code/noc-examples-p5.js/blob/master/chp00_introduction/NOC_I_05_NoiseWalk/sketch.js) file in [0.5 - NoiseWalk](https://github.com/nature-of-code/noc-examples-p5.js/tree/master/chp00_introduction/NOC_I_05_NoiseWalk)
```
Uncaught TypeError: walker.step is not a function
    at draw (sketch.js:14:10)
    at _.o.default.redraw (p5.min.js:3:493894)
    at _draw (p5.min.js:3:430041)
```

And fixed the [index.html](https://github.com/nature-of-code/noc-examples-p5.js/blob/master/chp01_vectors/NOC_1_02_bouncingball_vectors/index.html) merge conflicts from [this commit](https://github.com/nature-of-code/noc-examples-p5.js/commit/cb991f5fd24fe7933665d7a68f715166667083e0#diff-1c9017d3d7b4baf6a7fcc8dd37fcca4803dc903a27372c8c13cecec0abf3171b)